### PR TITLE
[Feat] 뉴스 페이지 쿼리 스트링 예외처리 추가 #64

### DIFF
--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -5,9 +5,9 @@ import { notFound } from "next/navigation";
 import { getNewsAction } from "@/libs/ServerAction/getNewsAction";
 
 export default async function Newspage({ searchParams, params }: any) {
-  if (params.slug) notFound();
   const { data } = await getNewsAction(searchParams.page, searchParams.sort);
 
+  if (params.slug || !data) notFound();
   return (
     <section className="w-full h-full relative flex flex-col border-t-[1px] border-[#CDD0E2] xl:border-none px-5 md:px-10">
       <DropDown />
@@ -17,7 +17,7 @@ export default async function Newspage({ searchParams, params }: any) {
             <NewsList key={index} data={news} />
           ))}
       </ul>
-      <Paginate totalCount={Math.ceil(data.totalElements / 5)} />
+      {data && <Paginate totalCount={Math.ceil(data.totalElements / 5)} />}
     </section>
   );
 }

--- a/src/libs/ServerAction/getNewsAction.ts
+++ b/src/libs/ServerAction/getNewsAction.ts
@@ -9,9 +9,13 @@ export async function getNewsAction(page: string, sort: string) {
       next: { revalidate: 0 },
     };
     const result = await fetch(url, options);
-    if (result.ok) {
+    if (result.ok && result.body) {
       const data = await result.json();
-      return { data, status: result.status };
+      if (data !== undefined) {
+        return { data, status: result.status };
+      }
+    } else {
+      return { data: undefined };
     }
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
< 뉴스 페이지 쿼리 스트링 예외처리 추가 >
- 쿼리 스트링 예외처리 추가
  - 예를 들면 아직 데이터가 없는 쿼리 스트링을 url을통해 강제로 접근할 경우 예외처리 페이지 렌더링
  - 백엔드에서 common status추가 하면 해당 status로 예외처리 진행 예정