### PR TITLE
[Fix] 뉴스 페이지 sort 쿼리 스트링 예외처리 추가 #64

### DIFF
--- a/src/libs/ServerAction/getNewsAction.ts
+++ b/src/libs/ServerAction/getNewsAction.ts
@@ -1,5 +1,6 @@
 export async function getNewsAction(page: string, sort: string) {
   try {
+    if (sort !== "asc" && sort !== "desc") return { data: undefined };
     const url = `${process.env.NEXT_PUBLIC_BASEURL}/news?page=${page}&sort=${sort}`;
     const options = {
       method: "get",


### PR DESCRIPTION
< 뉴스 페이지 sort 쿼리 스트링 예외처리 추가 >
- sort쿼리 스트링 "asc", "desc"외의 예외처리 추가